### PR TITLE
Support user labels and annotations in lightlytics chart

### DIFF
--- a/charts/lightlytics/templates/_helpers.tpl
+++ b/charts/lightlytics/templates/_helpers.tpl
@@ -64,11 +64,29 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+User labels
+*/}}
+{{- define "user.labels" -}}
+{{- with .Values.userLabels }}
+{{ toYaml .}}
+{{- end }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "lightlytics.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "lightlytics.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+User annotations
+*/}}
+{{- define "user.annotations" -}}
+{{- with .Values.userAnnotations }}
+{{ toYaml .}}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/lightlytics/templates/cost_deployment.yaml
+++ b/charts/lightlytics/templates/cost_deployment.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "lightlytics.labels" . | nindent 4 }}
+  {{- if .Values.userLabels }}
+  {{- include "user.labels" . | indent 4 }}
+  {{- end }}
+  {{- if .Values.userAnnotations }}
+  annotations:
+  {{- include "user.annotations" . | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.lightlytics.replicas }}
   selector:

--- a/charts/lightlytics/templates/deployment.yaml
+++ b/charts/lightlytics/templates/deployment.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "lightlytics.labels" . | nindent 4 }}
+  {{- if .Values.userLabels }}
+  {{- include "user.labels" . | indent 4 }}
+  {{- end }}
+  {{- if .Values.userAnnotations }}
+  annotations:
+  {{- include "user.annotations" . | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.lightlytics.replicas }}
   selector:

--- a/charts/lightlytics/templates/process_discovery_ds.yaml
+++ b/charts/lightlytics/templates/process_discovery_ds.yaml
@@ -6,6 +6,13 @@ metadata:
   labels:
   {{- include "lightlytics.labels" . | nindent 4 }}
     app: {{ template "lightlytics.fullname" . }}-process-discovery
+  {{- if .Values.userLabels }}
+  {{- include "user.labels" . | indent 4 }}
+  {{- end }}
+  {{- if .Values.userAnnotations }}
+  annotations:
+  {{- include "user.annotations" . | indent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/lightlytics/values.yaml
+++ b/charts/lightlytics/values.yaml
@@ -8,6 +8,10 @@ nameOverride:  # ""
 
 fullnameOverride:  # ""
 
+userLabels: {}
+
+userAnnotations: {}
+
 registry: public.ecr.aws/f1v0s3d7
 
 lightlytics:

--- a/charts/lightlytics/values.yaml.jinja2
+++ b/charts/lightlytics/values.yaml.jinja2
@@ -6,6 +6,10 @@ nameOverride:  # ""
 
 fullnameOverride:  # ""
 
+userLabels: # ""
+
+userAnnotations: # ""
+
 registry: {{ecr_repo}}
 
 lightlytics:


### PR DESCRIPTION
Adds support for user defined labels and annotations on the `cost_deployment.yaml`, `deployment.yaml` and `process_discovery_ds.yaml` templates