### PR TITLE
change tetragon filter and enable ancestors

### DIFF
--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -216,6 +216,5 @@ tetragon:
     name: "tetragon"
   tetragon:
     exportFileMaxSizeMB: 50
-    fieldFilters: |
-      {"fields": "parent", "action": "EXCLUDE"}
+
 

--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -216,7 +216,7 @@ tetragon:
     name: "tetragon"
   tetragon:
     exportFileMaxSizeMB: 50
-  fieldFilters: |
-    {"event_set":["PROCESS_KPROBE","PROCESS_EXIT"], "fields":"parent", "action":"EXCLUDE"}
+    fieldFilters: |
+      {"event_set":["PROCESS_KPROBE","PROCESS_EXIT"], "fields":"parent", "action":"EXCLUDE"}
 
 

--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -216,5 +216,7 @@ tetragon:
     name: "tetragon"
   tetragon:
     exportFileMaxSizeMB: 50
+  fieldFilters: |
+    {"event_set":["PROCESS_KPROBE","PROCESS_EXIT"], "fields":"parent", "action":"EXCLUDE"}
 
 

--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -216,6 +216,12 @@ tetragon:
     name: "tetragon"
   tetragon:
     exportFileMaxSizeMB: 50
+    image:
+      name: quay.io/cilium/tetragon-ci
+      tag: latest
+      pullPolicy: IfNotPresent
+    args:
+      - --enable-process-ancestors
     fieldFilters: |
       {"event_set":["PROCESS_KPROBE","PROCESS_EXIT"], "fields":"parent", "action":"EXCLUDE"}
 


### PR DESCRIPTION
in this PR i changed the filter on the tetragon service so it will not send us the parent field for PROCESS_KPROBE/PROCESS_EXIT events and i added a flag to enable the process ancestors for PROCESS_EXEC events