### PR TITLE
fix(streamsec-agent): use bare CSV value for enable-ancestors

### DIFF
--- a/charts/streamsec-agent/Chart.yaml
+++ b/charts/streamsec-agent/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.71
+version: 1.1.72
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/streamsec-agent/README.md
+++ b/charts/streamsec-agent/README.md
@@ -141,7 +141,7 @@ Stream Security Agent Helm Chart
 | tetragon.serviceAccount.name | string | `"tetragon"` |  |
 | tetragon.tetragon.exportDenyList | string | `"{\"event_set\": [\"PROCESS_EXIT\"]}"` |  |
 | tetragon.tetragon.exportFileMaxSizeMB | int | `50` |  |
-| tetragon.tetragon.extraArgs.enable-ancestors | string | `"[\"base\"]"` |  |
+| tetragon.tetragon.extraArgs.enable-ancestors | string | `"base"` |  |
 | tetragon.tetragon.extraArgs.enable-process-cred | bool | `true` |  |
 | tetragon.tetragon.fieldFilters | string | `"{\"event_set\":[\"PROCESS_KPROBE\"], \"fields\":\"parent\", \"action\":\"EXCLUDE\"}\n{\"event_set\":[\"PROCESS_KPROBE\",\"PROCESS_EXEC\"],\"fields\":\"process.parent_exec_id,parent.parent_exec_id,ancestors.parent_exec_id,parent.cwd,ancestors.exec_id\", \"action\":\"EXCLUDE\"}\n{\"event_set\":[\"PROCESS_EXEC\"],\"fields\":\"process.cap,parent.cap,parent.process_credentials,ancestors.cap,ancestors.process_credentials\", \"action\":\"EXCLUDE\"}\n"` |  |
 | tetragon.tetragon.grpc.address | string | `"localhost:59751"` |  |

--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -287,7 +287,7 @@ tetragon:
     healthGrpc:
       port: 9763
     extraArgs:
-      enable-ancestors: '["base"]'
+      enable-ancestors: base
       enable-process-cred: true
     exportFileMaxSizeMB: 50
     exportDenyList: |-


### PR DESCRIPTION
Tetragon's --enable-ancestors flag is parsed as a CSV string slice, not JSON. Rendering extraArgs as '["base"]' produced:

  invalid argument "[\"base\"]" for "--enable-ancestors" flag:
  parse error on line 1, column 2: bare " in non-quoted-field

Use the bare value "base" instead. Bumped chart to 1.1.72.