### PR TITLE
Adding response functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 helm-docs
 
 charts/streamsec-agent/charts
+charts/streamsec-agent/Chart.lock
 
 test.yaml

--- a/charts/streamsec-agent/templates/runtime_agent_ds.yaml
+++ b/charts/streamsec-agent/templates/runtime_agent_ds.yaml
@@ -43,6 +43,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- if .Values.streamsec.runtime_agent.responseActionsEnabled }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -76,6 +82,10 @@ spec:
             - name: RESOURCE_GROUP
               value: {{ .Values.streamsec.env.RESOURCE_GROUP | quote }}
             {{- end }}
+            {{- if .Values.streamsec.runtime_agent.responseActionsEnabled }}
+            - name: RESPONSE_ACTIONS_ENABLED
+              value: "true"
+            {{- end }}
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError
@@ -86,6 +96,10 @@ spec:
               name: export-logs
             - mountPath: /host/proc
               name: proc
+            {{- if .Values.streamsec.runtime_agent.responseActionsEnabled }}
+            - mountPath: /run/containerd/containerd.sock
+              name: containerd-sock
+            {{- end }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       hostNetwork: true
       hostPID: true
@@ -108,6 +122,12 @@ spec:
             path: /proc
             type: DirectoryOrCreate
           name: proc
+        {{- if .Values.streamsec.runtime_agent.responseActionsEnabled }}
+        - hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket
+          name: containerd-sock
+        {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds an optional host socket mount and new env vars to the privileged runtime-agent DaemonSet, which can affect node security posture and runtime compatibility when enabled. Also introduces a new ignored `Chart.lock`, reducing reproducibility visibility in the repo.
> 
> **Overview**
> Adds a `streamsec.runtime_agent.responseActionsEnabled` toggle to the runtime-agent DaemonSet template to enable “response actions” behavior.
> 
> When enabled, the pod now injects `POD_NAMESPACE` and `RESPONSE_ACTIONS_ENABLED=true`, and mounts the host `containerd` socket (`/run/containerd/containerd.sock`) into the privileged container.
> 
> Updates `.gitignore` to ignore `charts/streamsec-agent/Chart.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b22648a2bf6c31b266b6bb29e0943d7a17481073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->