### PR TITLE
DEV-20432 - feat(streamsec-agent): add AI_BODY_ENABLED and EXTERNAL_INBOUND_BODY_ENABLED env vars

### DIFF
--- a/charts/streamsec-agent/Chart.yaml
+++ b/charts/streamsec-agent/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.75
+version: 1.1.76
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/streamsec-agent/README.md
+++ b/charts/streamsec-agent/README.md
@@ -1,6 +1,6 @@
 # streamsec-agent
 
-![Version: 1.1.75](https://img.shields.io/badge/Version-1.1.75-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.4](https://img.shields.io/badge/AppVersion-1.1.4-informational?style=flat-square)
+![Version: 1.1.76](https://img.shields.io/badge/Version-1.1.76-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.4](https://img.shields.io/badge/AppVersion-1.1.4-informational?style=flat-square)
 
 Stream Security Agent Helm Chart
 

--- a/charts/streamsec-agent/README.md
+++ b/charts/streamsec-agent/README.md
@@ -85,6 +85,8 @@ Stream Security Agent Helm Chart
 | streamsec.cost_image.tag | string | `"1.2.10"` | Stream Security cost agent tag to use. |
 | streamsec.dnsConfig | object | `{}` |  |
 | streamsec.env.ACCOUNT_ID | string | `nil` |  |
+| streamsec.env.AI_BODY_ENABLED | string | `nil` | Enable AI body processing |
+| streamsec.env.EXTERNAL_INBOUND_BODY_ENABLED | string | `nil` | Enable external inbound body processing |
 | streamsec.env.CLUSTER_ID | string | `nil` |  |
 | streamsec.env.CLUSTER_NAME | string | `nil` |  |
 | streamsec.env.DEBUG | string | `"false"` |  |

--- a/charts/streamsec-agent/templates/runtime_agent_ds.yaml
+++ b/charts/streamsec-agent/templates/runtime_agent_ds.yaml
@@ -86,6 +86,14 @@ spec:
             - name: RESPONSE_ACTIONS_ENABLED
               value: "true"
             {{- end }}
+            {{- if .Values.streamsec.env.AI_BODY_ENABLED }}
+            - name: AI_BODY_ENABLED
+              value: {{ .Values.streamsec.env.AI_BODY_ENABLED | quote }}
+            {{- end }}
+            {{- if .Values.streamsec.env.EXTERNAL_INBOUND_BODY_ENABLED }}
+            - name: EXTERNAL_INBOUND_BODY_ENABLED
+              value: {{ .Values.streamsec.env.EXTERNAL_INBOUND_BODY_ENABLED | quote }}
+            {{- end }}
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError

--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -269,6 +269,8 @@ streamsec:
     ACCOUNT_ID:  # "" 
     REGION:  # "" 
     RESOURCE_GROUP:  # ""
+    AI_BODY_ENABLED:  # ""
+    EXTERNAL_INBOUND_BODY_ENABLED:  # ""
 
 tetragon:
   serviceAccount:


### PR DESCRIPTION
## Summary
- Add `AI_BODY_ENABLED` and `EXTERNAL_INBOUND_BODY_ENABLED` optional env vars to the runtime agent
- Values defined under `streamsec.env` following the existing conditional pattern (same as `ACCOUNT_ID`, `CLUSTER_ID`, etc.)
- Env vars are omitted when not set, included only when explicitly enabled

## Test plan
- [ ] `helm template` renders correctly with both vars set to `true`
- [ ] `helm template` omits both vars when not set
- [ ] Verify runtime agent pod picks up the env vars after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)