### PR TITLE
DEV-20663: PriorityClass so runtime node agents schedule on fully-packed nodes

### DIFF
--- a/charts/streamsec-agent/Chart.yaml
+++ b/charts/streamsec-agent/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.76
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/streamsec-agent/README.md
+++ b/charts/streamsec-agent/README.md
@@ -1,6 +1,6 @@
 # streamsec-agent
 
-![Version: 1.1.76](https://img.shields.io/badge/Version-1.1.76-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.4](https://img.shields.io/badge/AppVersion-1.1.4-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.4](https://img.shields.io/badge/AppVersion-1.1.4-informational?style=flat-square)
 
 Stream Security Agent Helm Chart
 
@@ -112,6 +112,12 @@ Stream Security Agent Helm Chart
 | streamsec.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | streamsec.podSecurityContext.supplementalGroups[0] | int | `1000` |  |
 | streamsec.port | int | `443` | streamsec port |
+| streamsec.priorityClass.create | bool | `true` | Render the PriorityClass object with the chart. Set false to reference an externally pre-created class of the same `name`. Only takes effect when enabled: true. |
+| streamsec.priorityClass.description | string | `"StreamSec node agents - must run on every node."` | Human-readable description on the PriorityClass object. |
+| streamsec.priorityClass.enabled | bool | `false` | Master switch. When true, the node-agent DaemonSets (runtime-agent, process-discovery) get priorityClassName set so they can schedule/preempt on fully-packed nodes (DEV-20663). Default false for staged rollout. |
+| streamsec.priorityClass.name | string | `"streamsec-agent-critical"` | Name of the PriorityClass, used for both the created object and the priorityClassName reference. |
+| streamsec.priorityClass.preemptionPolicy | string | `"PreemptLowerPriority"` | PreemptLowerPriority lets the agent evict a priority-0 pod to fit on a full node. Set to Never for schedule-only (no eviction). |
+| streamsec.priorityClass.value | int | `1000000000` | Priority value. Must be >> 0 and < system-cluster-critical (2000000000). Immutable after creation. |
 | streamsec.process_discovery_containers.containers.process-discovery.name | string | `"process-discovery"` |  |
 | streamsec.process_discovery_containers.containers.process-discovery.resources | object | `{}` |  |
 | streamsec.process_discovery_containers.enabled | bool | `false` |  |
@@ -140,6 +146,7 @@ Stream Security Agent Helm Chart
 | streamsec.tolerations[0].value | string | `"true"` |  |
 | streamsec.workflow | string | `"full_scan"` | streamsec workflow type  |
 | tetragon.export.mode | string | `""` |  |
+| tetragon.priorityClassName | string | `""` | PriorityClass for the Tetragon sensor DaemonSet (the ~200m node agent runtime-agent reads from). When enabling streamsec.priorityClass, set this to the SAME class name (default: streamsec-agent-critical). Tetragon is a subchart and cannot read streamsec.priorityClass.enabled, so set it explicitly. |
 | tetragon.serviceAccount.name | string | `"tetragon"` |  |
 | tetragon.tetragon.exportDenyList | string | `"{\"event_set\": [\"PROCESS_EXIT\"]}"` |  |
 | tetragon.tetragon.exportFileMaxSizeMB | int | `50` |  |

--- a/charts/streamsec-agent/templates/_helpers.tpl
+++ b/charts/streamsec-agent/templates/_helpers.tpl
@@ -108,3 +108,14 @@ Create the name of the service account to use
 {{- define "streamsec.clusterRoleName" -}}
 {{- coalesce (.Values.streamsec.clusterRole.name) (printf "%s-cluster-role" .Release.Name) }}
 {{- end }}
+
+{{/*
+Effective PriorityClass name for the node-agent DaemonSets.
+Returns the configured name only when priorityClass.enabled is true, otherwise empty
+(so callers can `if`/`default` on it and omit priorityClassName entirely when disabled).
+*/}}
+{{- define "streamsec.priorityClassName" -}}
+{{- if .Values.streamsec.priorityClass.enabled -}}
+{{- .Values.streamsec.priorityClass.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/streamsec-agent/templates/priorityclass.yaml
+++ b/charts/streamsec-agent/templates/priorityclass.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.streamsec.priorityClass.enabled .Values.streamsec.priorityClass.create }}
+# Cluster-scoped PriorityClass for the StreamSec node-agent DaemonSets (see DEV-20663).
+# Created by Helm at install time using the installer's credentials (needs create on
+# scheduling.k8s.io/priorityclasses) — NOT by the agent runtime ServiceAccount.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.streamsec.priorityClass.name }}
+  labels:
+  {{- include "streamsec.labels" . | nindent 4 }}
+value: {{ .Values.streamsec.priorityClass.value | int }}
+globalDefault: false
+preemptionPolicy: {{ .Values.streamsec.priorityClass.preemptionPolicy | default "PreemptLowerPriority" }}
+description: {{ .Values.streamsec.priorityClass.description | quote }}
+{{- end }}

--- a/charts/streamsec-agent/templates/process_discovery_ds.yaml
+++ b/charts/streamsec-agent/templates/process_discovery_ds.yaml
@@ -22,6 +22,10 @@ spec:
         app: {{ template "streamsec.fullname" . }}-process-discovery
     spec:
       serviceAccountName: {{ template "streamsec.serviceAccountName" . }}
+      {{- $priorityClassName := include "streamsec.priorityClassName" . }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.streamsec.podSecurityContext | nindent 8 }}
       tolerations:

--- a/charts/streamsec-agent/templates/runtime_agent_ds.yaml
+++ b/charts/streamsec-agent/templates/runtime_agent_ds.yaml
@@ -112,8 +112,9 @@ spec:
       hostNetwork: true
       hostPID: true
       hostIPC: true
-      {{- with .Values.streamsec.runtime_agent.priorityClassName }}
-      priorityClassName: "{{ . }}"
+      {{- $priorityClassName := default (include "streamsec.priorityClassName" .) .Values.streamsec.runtime_agent.priorityClassName }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
       {{- end }}
       serviceAccountName: {{ template "streamsec.serviceAccountName" . }}
       terminationGracePeriodSeconds: 1

--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -81,6 +81,46 @@ streamsec:
 
   replicas: 1
 
+  # priorityClass -- Dedicated PriorityClass for the node-agent DaemonSets (runtime-agent and
+  # process-discovery). Without it these pods run at priority 0 and can be left Pending on a
+  # fully-packed node (they target one existing node and cannot move elsewhere), leaving that
+  # node with no runtime security agent. See DEV-20663.
+  #
+  # NOTE: PriorityClass is a CLUSTER-SCOPED resource. Rendering it (create: true) requires the
+  # Helm installer's credentials to have create permission on scheduling.k8s.io/priorityclasses
+  # (cluster-admin does). It is created at install time by Helm, NOT by the agent's runtime
+  # ServiceAccount, so no addition to the agent ClusterRole is required. If your install path
+  # cannot create cluster-scoped objects, either pre-create the PriorityClass out of band and set
+  # create: false (the DaemonSets will reference it by `name`), or leave enabled: false.
+  priorityClass:
+    # streamsec.priorityClass.enabled -- Master switch. When true, the node-agent DaemonSets get
+    # priorityClassName set. Default false for a staged rollout (enable on your own clusters /
+    # a demo env first, then customers) because preemption is a behavior change (see below).
+    enabled: false
+
+    # streamsec.priorityClass.create -- Render the PriorityClass object with the chart. Set false
+    # to reference an externally pre-created class of the same `name` (e.g. when the installer
+    # lacks RBAC to create cluster-scoped resources). Only takes effect when enabled: true.
+    create: true
+
+    # streamsec.priorityClass.name -- Name of the PriorityClass, used both for the created object
+    # and the priorityClassName reference on the DaemonSets.
+    name: streamsec-agent-critical
+
+    # streamsec.priorityClass.value -- Priority value. Must be >> 0 (the default for unclassed
+    # pods) and < system-cluster-critical (2000000000). Immutable after creation.
+    value: 1000000000
+
+    # streamsec.priorityClass.preemptionPolicy -- PreemptLowerPriority lets the agent EVICT a
+    # priority-0 workload pod to fit on a full node (required here: a DaemonSet can't relocate;
+    # the evicted pod reschedules elsewhere / triggers cluster autoscaling, or waits for capacity
+    # on clusters without an autoscaler). Set to Never for schedule-only (no eviction; the agent
+    # may stay Pending on packed nodes).
+    preemptionPolicy: PreemptLowerPriority
+
+    # streamsec.priorityClass.description -- Human-readable description on the PriorityClass object.
+    description: "StreamSec node agents - must run on every node."
+
   # podSecurityContext -- Security context applied at the pod level for all non-privileged workloads
   # (cluster_agent, cost, process_discovery). Override in your values to adjust for your PSP/PSS policies.
   podSecurityContext:
@@ -273,6 +313,13 @@ streamsec:
     EXTERNAL_INBOUND_BODY_ENABLED:  # ""
 
 tetragon:
+  # tetragon.priorityClassName -- PriorityClass for the Tetragon sensor DaemonSet (the ~200m
+  # node agent that runtime-agent reads from). It has the same "priority 0, can't reschedule"
+  # exposure as the StreamSec DaemonSets (DEV-20663), so when enabling streamsec.priorityClass
+  # set this to the SAME class name (default: streamsec-agent-critical). Left empty by default.
+  # NOTE: Tetragon is a subchart and cannot read streamsec.priorityClass.enabled, so this must be
+  # set explicitly alongside it (both are typically set together in your per-install values overlay).
+  priorityClassName: ""
   serviceAccount:
     name: tetragon
   export:


### PR DESCRIPTION
## Problem (DEV-20663)

In prod (`new-prod-lightlytics-eks_cluster`) a `streamsec-agent-runtime-agent` DaemonSet pod sat **Pending ~167 min** on node `ip-10-0-33-88` (r6i.xlarge, 3920m alloc). Two `scan` pods packed the node to ~3.88 cores, leaving <100m. The agent requests 100m and has **no `priorityClassName` (priority 0)**, so it can neither fit **nor preempt** the equal-priority pods (`No preemption victims found`). Result: **the node runs with no runtime security agent.**

The CPU-requesting node DaemonSets exposed to this are:
- `streamsec-agent` — the **tetragon** sensor (~200m), which runtime-agent reads from
- `streamsec-agent-runtime-agent` (100m)
- `streamsec-agent-process-discovery` (BestEffort today, but included for consistency)

`process-discovery` and Datadog schedule only because they're BestEffort (0 CPU request) — that's luck, not design.

## Fix — Option A (prioritization), as chosen by the team

- New cluster-scoped **PriorityClass `streamsec-agent-critical`**, value `1000000000` (≫ default 0, < `system-cluster-critical` 2000000000), `preemptionPolicy: PreemptLowerPriority`, `globalDefault: false`. Deliberately **not** `system-node-critical` (reserved for CNI/kube-proxy/CSI, namespace-restricted, too aggressive).
- `priorityClassName` set on the runtime-agent + process-discovery DaemonSets (via a `streamsec.priorityClassName` helper) and on the tetragon sensor DaemonSet (`tetragon.priorityClassName`).
- Everything behind a `streamsec.priorityClass` values block (`enabled` / `create` / `name` / `value` / `preemptionPolicy` / `description`).

## ⚠️ Behavior change — preemption

Because a DaemonSet targets **one existing node** and no new node is added for it, preemption is **required**: on a full node the agent will **evict one priority-0 workload pod** to claim its CPU. That pod reschedules elsewhere / triggers cluster autoscaling (Karpenter on our clusters) — or, on customer clusters **without an autoscaler, it may simply go Pending until capacity frees**. This is customer-facing.

### Staged rollout (why `enabled: false` by default)
1. Merge → chart-releaser publishes `1.2.0` (no behavior change; feature off).
2. Enable on **our prod + a demo env** first (set `streamsec.priorityClass.enabled=true` and `tetragon.priorityClassName=streamsec-agent-critical` in the overlay); confirm no agent Pending on packed nodes and the preempted workload recovers.
3. Then flip the default / roll to customers in a follow-up.

## RBAC note
`PriorityClass` is cluster-scoped but is created by **Helm at install time using the installer's credentials** (cluster-admin has `create` on `scheduling.k8s.io/priorityclasses`), **not** by the agent's runtime ServiceAccount — so no change to the agent ClusterRole is needed. If an install path can't create cluster-scoped objects, set `create: false` and reference a pre-created class of the same name, or leave `enabled: false`.

## Validation
- `helm lint` + `helm template`: PriorityClass renders; `priorityClassName` set on all three node DaemonSets when enabled; **nothing** rendered when disabled (default); `create: false` sets the name but omits the object; runtime-agent per-workload override still wins.
- Fixed a real bug: raw `value` rendered as `1e+09` (invalid for int32) → forced with `| int`.
- **Server-side dry-run** of the PriorityClass against `new-prod-lightlytics-eks_cluster`: `priorityclass.scheduling.k8s.io/streamsec-agent-critical created (server dry run)` — accepted, nothing persisted.

Full deploy verification (pods no longer Pending on packed nodes) happens at rollout step 2 once the chart is published and the overlay enables it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)