### PR TITLE
DEV-21601 release(agent): pin official cluster-agent 1.2.11

### DIFF
--- a/charts/streamsec-agent/Chart.yaml
+++ b/charts/streamsec-agent/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.7
+version: 1.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -137,10 +137,10 @@ streamsec:
     name: cluster-agent
 
     #streamsec.image.tag -- Stream Security agent tag to use.
-    tag: 1.2.10
+    tag: 1.2.11
 
     #streamsec.image.digest -- Stream Security agent image digest to use.
-    digest: sha256:6b5021f226cc7dd217615a0715790b4b00515d6fd162ec6790d2956410b84f93
+    digest: sha256:674ef1625dc3c165ffc934efdd81ad54ecbd67419e2184c8c6ea4059caea4f50
 
     #streamsec.image.pullPolicy -- Stream Security agent image pullPolicy
     pullPolicy: IfNotPresent
@@ -151,10 +151,10 @@ streamsec:
     name: cluster-agent
 
     #streamsec.cost_image.tag -- Stream Security cost agent tag to use.
-    tag: 1.2.10
+    tag: 1.2.11
 
     #streamsec.cost_image.digest -- Stream Security cost agent image digest to use.
-    digest: sha256:6b5021f226cc7dd217615a0715790b4b00515d6fd162ec6790d2956410b84f93
+    digest: sha256:674ef1625dc3c165ffc934efdd81ad54ecbd67419e2184c8c6ea4059caea4f50
 
     #streamsec.cost_image.pullPolicy -- Stream Security cost agent image pullPolicy
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Pins streamsec-agent to the official **1.2.11** image (built from master after MIKA #68 merged), by index digest `sha256:674ef1625dc3c165ffc934efdd81ad54ecbd67419e2184c8c6ea4059caea4f50`. This ships the new k8s inventory kinds + pod→configmap/secret refs to production. Chart 1.2.7→1.2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMgU2HmAZ1RPjaJTkWpcFu