### PR TITLE
DEV-21601 fix(agent): pin cluster-agent 1.2.12 (ConfigMap cert/key redaction)

### DIFF
--- a/charts/streamsec-agent/Chart.yaml
+++ b/charts/streamsec-agent/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.8
+version: 1.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/streamsec-agent/values.yaml
+++ b/charts/streamsec-agent/values.yaml
@@ -137,10 +137,10 @@ streamsec:
     name: cluster-agent
 
     #streamsec.image.tag -- Stream Security agent tag to use.
-    tag: 1.2.11
+    tag: 1.2.12
 
     #streamsec.image.digest -- Stream Security agent image digest to use.
-    digest: sha256:674ef1625dc3c165ffc934efdd81ad54ecbd67419e2184c8c6ea4059caea4f50
+    digest: sha256:953926202f916cc60049d9162a13c9faa61fefc1187de122e62f2a42dd49b2b4
 
     #streamsec.image.pullPolicy -- Stream Security agent image pullPolicy
     pullPolicy: IfNotPresent
@@ -151,10 +151,10 @@ streamsec:
     name: cluster-agent
 
     #streamsec.cost_image.tag -- Stream Security cost agent tag to use.
-    tag: 1.2.11
+    tag: 1.2.12
 
     #streamsec.cost_image.digest -- Stream Security cost agent image digest to use.
-    digest: sha256:674ef1625dc3c165ffc934efdd81ad54ecbd67419e2184c8c6ea4059caea4f50
+    digest: sha256:953926202f916cc60049d9162a13c9faa61fefc1187de122e62f2a42dd49b2b4
 
     #streamsec.cost_image.pullPolicy -- Stream Security cost agent image pullPolicy
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Supersedes 1.2.11 with the **critical security fix** from [MIKA#69](https://github.com/lightlytics/MIKA/pull/69): cert/key material in ConfigMap values is redacted at the agent **before egress**, per Stav/Liran. Pinned by index digest `sha256:953926202f916cc60049d9162a13c9faa61fefc1187de122e62f2a42dd49b2b4`. Chart 1.2.8→1.2.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMgU2HmAZ1RPjaJTkWpcFu